### PR TITLE
New Relic setup again

### DIFF
--- a/lib/wilbertils.rb
+++ b/lib/wilbertils.rb
@@ -6,6 +6,7 @@ require "wilbertils/sqs"
 require "wilbertils/ftp_paths"
 require "wilbertils/file_archiver"
 require "wilbertils/exception_handler"
+require "wilbertils/error_handler"
 require "wilbertils/message_receiver"
 require "wilbertils/message_receiver_new"
 require "wilbertils/airbrake_delivery_worker"
@@ -17,6 +18,7 @@ require "wilbertils/redis/processing_queues"
 require "wilbertils/encrypt_decrypt"
 require "wilbertils/ftp_paths"
 require "wilbertils/authorization/oauth2"
+require "wilbertils/logger"
 
 module Wilbertils
 end

--- a/lib/wilbertils/error_handler.rb
+++ b/lib/wilbertils/error_handler.rb
@@ -1,0 +1,30 @@
+require 'active_support/concern'
+require 'active_support/rescuable'
+
+module Wilbertils
+  module ErrorHandler
+    extend ActiveSupport::Concern
+    include ActiveSupport::Rescuable
+
+    included do
+      rescue_from StandardError, :with => :rescue_error
+    end
+
+    def rescue_error(error, **options)
+      self.class.rescue_error(error, **options)
+    end
+
+    def self.rescue_error(error, **options)
+      log = defined?(logger) ? logger : Rails.logger
+
+      log.error options[:detailed_message] if options[:detailed_message].present?
+      log.error "ErrorHandler: #{error.class} #{error.message}"
+      log.error error.backtrace.join("\n")
+
+      NewRelic::Agent.notice_error(error, options)
+      Airbrake.notify(error, options)
+    end
+
+  end
+end
+

--- a/lib/wilbertils/exception_handler.rb
+++ b/lib/wilbertils/exception_handler.rb
@@ -18,10 +18,8 @@ module Wilbertils
 
       return if !ENV['ENVIRONMENT_NAME']
 
-      Airbrake.notify(
-        exception,
-        :cgi_data => ENV.to_hash
-      )
+      NewRelic::Agent.notice_error(exception)
+      Airbrake.notify(exception)
     end
 
   end

--- a/lib/wilbertils/logger.rb
+++ b/lib/wilbertils/logger.rb
@@ -1,0 +1,16 @@
+module Wilbertils
+  class Logging
+    class << self
+      def logger(config)
+        @logger ||= if config.environment == 'development'
+          l = ActiveSupport::Logger.new("log/#{config.environment}.log")
+          l.formatter = proc { |sev, date, _, msg| "#{date.strftime('%Y-%m-%d %H:%M:%S')} #{sev}: #{msg}\n" }
+          l
+        else
+          # This logger is just a wrapper around Logger that sets a NewRelic JSON decorator
+          NewRelic::Agent::Logging::DecoratingLogger.new("#{config.environment}")
+        end
+      end
+    end
+  end
+end

--- a/lib/wilbertils/version.rb
+++ b/lib/wilbertils/version.rb
@@ -1,3 +1,3 @@
 module Wilbertils
-  VERSION = "1.5.7"
+  VERSION = "1.6.0"
 end

--- a/wilbertils.gemspec
+++ b/wilbertils.gemspec
@@ -21,7 +21,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "rake"
-  spec.add_runtime_dependency "log4r", "~> 1.1.10"
+  # At time of updating newrelic_rpm v9 caused a load issue with ActiveSupport::Logger
+  spec.add_runtime_dependency 'newrelic_rpm', '~> 8.16'
   spec.add_runtime_dependency "statsd-ruby"
   spec.add_runtime_dependency 'aws-sdk', '3.1.0'
   spec.add_runtime_dependency 'airbrake', '13.0.0'


### PR DESCRIPTION
Created a new ErrorHandler that rescues StandardError to be used instead of ExceptionHandler which rescues Exception. For this transition period both airbrake and new relic will notify on errors. Airbrake will later be removed.
For improved logging reporting the logger is being changed to be a New relic one for UAT/QA/PROD environments. Change the Development logger to just be the ruby logger because it isn't needed and doesn't play well with new relic. This moves log rotation responsibility on to the infrastructure (logrotate).
These are being done in wilbertils to allow standardizing error reporting and logging across all myfreight applications.
