### PR TITLE
oauth2_time_out_param

### DIFF
--- a/lib/wilbertils/version.rb
+++ b/lib/wilbertils/version.rb
@@ -1,3 +1,3 @@
 module Wilbertils
-  VERSION = "1.6.4"
+  VERSION = "1.6.5"
 end


### PR DESCRIPTION
- replaced RestClient.post with RestClient::Resource.new to use timeout option
- RestClient timeout in Oauth2 is able to be configured by params[:timeout]
- if params[:timeout] is not present, it will fetch from REST_CLIENT_DEFAULT_TIMEOUT env variable with fallback 10s