### PR TITLE
Record invalid error added to ErrorHandler

### DIFF
--- a/lib/wilbertils/authorization/oauth2.rb
+++ b/lib/wilbertils/authorization/oauth2.rb
@@ -15,8 +15,13 @@ module Wilbertils::Authorization
         begin
           token = retreive_access_token_from_redis
           token = refresh_token(token) if expired?(token)
-          return token[token_name] if token
-          request_access_token
+          if token
+            logger.info 'Using existing oauth token'
+            token[token_name]
+          else
+            logger.info 'Requesting new oauth token'
+            request_access_token
+          end
         rescue => e
           logger.error e.message
           logger.error e.backtrace

--- a/lib/wilbertils/error_handler.rb
+++ b/lib/wilbertils/error_handler.rb
@@ -11,11 +11,18 @@ module Wilbertils
       rescue_from(ActionController::InvalidAuthenticityToken)  { |e| rescue_error(e, error_code: :unauthorized,   status: :unauthorized) }
       rescue_from(ActiveRecord::StaleObjectError)              { |e| rescue_error(e, error_code: :stale,          status: :internal_server_error) }
       rescue_from(ActiveRecord::RecordNotFound)                { |e| rescue_error(e, error_code: :missing_record, status: :not_found) }
+      rescue_from(ActiveRecord::RecordInvalid)                 { |e| rescue_invalid_record(e) }
     end
 
     def rescue_error(error, **options)
       Wilbertils::ErrorHandler.rescue_error(error, **options)
       render_error(error, options[:error_code], options[:status]) unless options[:render_error] == false
+    end
+
+    def rescue_invalid_record error, **options
+      rescue_error(error, **options.merge(render_error: false))
+      return unless defined?(render)
+      render json: { errors: error.record.errors }, status: options[:status] || :bad_request
     end
 
     def render_error error, code, status

--- a/lib/wilbertils/version.rb
+++ b/lib/wilbertils/version.rb
@@ -1,3 +1,3 @@
 module Wilbertils
-  VERSION = "1.6.5"
+  VERSION = "1.6.6"
 end


### PR DESCRIPTION
For sites and site services errors are now allowed to raise up to the error handler but need a specific body to be returned to show in the front end.
