### PR TITLE
Require active record errors to fix load order error.

### DIFF
--- a/lib/wilbertils/version.rb
+++ b/lib/wilbertils/version.rb
@@ -1,3 +1,3 @@
 module Wilbertils
-  VERSION = "1.6.6"
+  VERSION = "1.6.7"
 end


### PR DESCRIPTION
Also handle ActiveRecord not being defined as it is not and should not be a dependency. That way Wilbertils can still be used on non rails applications.
