### PR TITLE
Silent error

### DIFF
--- a/lib/wilbertils/version.rb
+++ b/lib/wilbertils/version.rb
@@ -1,3 +1,3 @@
 module Wilbertils
-  VERSION = "1.6.7"
+  VERSION = "1.6.8"
 end


### PR DESCRIPTION
Created a silent error that doesn't raise an Airbrake or New Relic notification. Initially implemented to silence 404 errors from Locate2u POD downloads.
