### PR TITLE
SilentError type check

### DIFF
--- a/lib/wilbertils/error_handler.rb
+++ b/lib/wilbertils/error_handler.rb
@@ -49,8 +49,8 @@ module Wilbertils
       log.error "ErrorHandler: #{error.class} #{error.message}"
       log.error error.backtrace.join("\n")
 
-      NewRelic::Agent.notice_error(error, options) unless options[:error_code] == :silenced
-      Airbrake.notify(error, options) unless options[:error_code] == :silenced
+      NewRelic::Agent.notice_error(error, options) unless options[:error_code] == :silenced || error.is_a?(SilentError)
+      Airbrake.notify(error, options) unless options[:error_code] == :silenced || error.is_a?(SilentError)
     end
 
   end

--- a/lib/wilbertils/version.rb
+++ b/lib/wilbertils/version.rb
@@ -1,3 +1,3 @@
 module Wilbertils
-  VERSION = "1.6.10"
+  VERSION = "1.6.11"
 end


### PR DESCRIPTION
All SilentError should be silent, the error code allows for silencing other errors through rescue_from format while other errors can be silenced through just using the silent error type.
