### PR TITLE
set up password credentials in oauth2

### DIFF
--- a/lib/wilbertils/authorization/oauth2.rb
+++ b/lib/wilbertils/authorization/oauth2.rb
@@ -52,6 +52,9 @@ module Wilbertils::Authorization
         case @@params[:grant_type].to_sym
         when :client_credentials
           { Authorization: "Basic #{Base64.strict_encode64("#{@@params[:body][:client_id]}:#{@@params[:body][:client_secret]}")}" }
+        when :password_credentials
+          {"Content-Type": 'application/x-www-form-urlencoded',
+           Authorization: "Basic #{Base64.strict_encode64("#{@@params[:body][:client_id]}:#{@@params[:body][:client_secret]}")}" }
         else 
           {}
         end.merge(@@params[:headers] || {})
@@ -65,6 +68,14 @@ module Wilbertils::Authorization
         case @@params[:grant_type].to_sym
         when :password, :client_credentials_body
           @@params[:body]
+        when :password_credentials
+          @@params[:body]
+          {
+            grant_type: 'password',
+            scope: @@params[:scope],
+            username: @@params[:body][:username],
+            password: @@params[:body][:password]
+          }
         else
           {}
         end

--- a/lib/wilbertils/authorization/oauth2.rb
+++ b/lib/wilbertils/authorization/oauth2.rb
@@ -53,8 +53,7 @@ module Wilbertils::Authorization
         when :client_credentials
           { Authorization: "Basic #{Base64.strict_encode64("#{@@params[:body][:client_id]}:#{@@params[:body][:client_secret]}")}" }
         when :password_credentials
-          {"Content-Type": 'application/x-www-form-urlencoded',
-           Authorization: "Basic #{Base64.strict_encode64("#{@@params[:body][:client_id]}:#{@@params[:body][:client_secret]}")}" }
+          { Authorization: "Basic #{Base64.strict_encode64("#{@@params[:body][:client_id]}:#{@@params[:body][:client_secret]}")}" }
         else 
           {}
         end.merge(@@params[:headers] || {})
@@ -69,7 +68,6 @@ module Wilbertils::Authorization
         when :password, :client_credentials_body
           @@params[:body]
         when :password_credentials
-          @@params[:body]
           {
             grant_type: 'password',
             scope: @@params[:scope],

--- a/lib/wilbertils/version.rb
+++ b/lib/wilbertils/version.rb
@@ -1,3 +1,3 @@
 module Wilbertils
-  VERSION = "1.6.11"
+  VERSION = "1.6.12"
 end

--- a/lib/wilbertils/version.rb
+++ b/lib/wilbertils/version.rb
@@ -1,3 +1,3 @@
 module Wilbertils
-  VERSION = "1.6.12"
+  VERSION = "1.7.11"
 end


### PR DESCRIPTION
Bascik API uses password credential grant type for requesting access token. This PR sets up password-credentials configuration in oauth2.