### PR TITLE
Runtime error handling.

### DIFF
--- a/lib/wilbertils/error_handler.rb
+++ b/lib/wilbertils/error_handler.rb
@@ -11,6 +11,7 @@ module Wilbertils
 
     included do
       rescue_from(StandardError)                               { |e| rescue_error(e, error_code: :unhandled,    status: :internal_server_error) }
+      rescue_from(RuntimeError)                                { |e| rescue_error(e, error_code: :general,      status: :bad_request) }
       rescue_from(SilentError)                                 { |e| rescue_error(e, error_code: :silenced,     status: :bad_request) }
 
       # Wilbertils is used in non rails applications so check that rails is present for rails specific errors.
@@ -38,7 +39,10 @@ module Wilbertils
 
     def render_error error, code, status
       return unless defined?(render)
-      render json: { errors: [ { message: error.message, error_code: code || :unhandled } ] },
+      render json: { errors: [ {
+          message: [nil,:unhandled].include?(code) ? 'Unexpected error occurred.' : error.message,
+          error_code: code || :unhandled
+        } ] },
         status: status || :internal_server_error
     end
 

--- a/lib/wilbertils/version.rb
+++ b/lib/wilbertils/version.rb
@@ -1,3 +1,3 @@
 module Wilbertils
-  VERSION = "1.7.11"
+  VERSION = "1.7.12"
 end


### PR DESCRIPTION
When errors are deliberately raised, IE Runtime errors, we'll put something that will likely be useful to the user in the error. Unhandled errors, IE relying on StandardError, will usually be a missing method error or argument error where the error message will be referring to something to do with code. These shouldn't be shown to the user.
