### PR TITLE
update airbrake, bundler and ruby version

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,7 @@ TODO: Write usage instructions here
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create new Pull Request
+
+## Ruby Version
+
+Wilbertils should work with any version of Ruby from the other MF repositories. We can not pin it's version down exactly as sometimes the projects are slightly out of sync.

--- a/lib/wilbertils/version.rb
+++ b/lib/wilbertils/version.rb
@@ -1,3 +1,3 @@
 module Wilbertils
-  VERSION = "1.9.6"
+  VERSION = "1.9.7"
 end

--- a/wilbertils.gemspec
+++ b/wilbertils.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'newrelic_rpm', '~> 9.6'
   spec.add_runtime_dependency "statsd-ruby"
   spec.add_runtime_dependency 'aws-sdk', '3.1.0'
-  spec.add_runtime_dependency 'airbrake', '13.0.0'
+  spec.add_runtime_dependency 'airbrake', '13.0.4'
   spec.add_runtime_dependency 'sucker_punch', '1.0.2'
   spec.add_runtime_dependency 'activesupport'
   spec.add_runtime_dependency 'redis-queue', '0.1.0'


### PR DESCRIPTION
Updated Airbrake gem.

Took a bit of time to find a ruby version that worked and added `.ruby-version` file to avoid this in the future.