### PR TITLE
Version up to 1.12.1

### DIFF
--- a/lib/wilbertils/authorization/oauth2.rb
+++ b/lib/wilbertils/authorization/oauth2.rb
@@ -153,7 +153,8 @@ module Wilbertils::Authorization
 
     def expired? token
       # default of 1 hr set, sometimes medipt send back nil and need to handle it
-      !!token && ( ( Time.now.to_i - Time.parse(token[:created_at]).to_i ) > ( token[:expires_in] || 3600 ) )
+      # Added 60s leeway to ensure token is still valid when it reaches the client endpoint
+      !!token && ( ( Time.now.to_i - Time.parse(token[:created_at]).to_i ) > ( (token[:expires_in] - 60) || 3600 ) )
     end
 
     def redis

--- a/lib/wilbertils/version.rb
+++ b/lib/wilbertils/version.rb
@@ -1,3 +1,3 @@
 module Wilbertils
-  VERSION = "1.12.0"
+  VERSION = "1.13.0"
 end


### PR DESCRIPTION
Added 60s leeway to the expired? logic in oauth2 to ensure token is still valid when it reaches the client endpoint