### PR TITLE
Fix Oauth2 token expiry issue.

### DIFF
--- a/lib/wilbertils/authorization/oauth2.rb
+++ b/lib/wilbertils/authorization/oauth2.rb
@@ -154,7 +154,7 @@ module Wilbertils::Authorization
     def expired? token
       # default of 1 hr set, sometimes medipt send back nil and need to handle it
       # Added 60s leeway to ensure token is still valid when it reaches the client endpoint
-      !!token && ( ( Time.now.to_i - Time.parse(token[:created_at]).to_i ) > ( (token[:expires_in] - 60) || 3600 ) )
+      !!token && ( ( Time.now.to_i - Time.parse(token[:created_at]).to_i ) > ( (token[:expires_in].present? ? (token[:expires_in] - 60) : nil) || 3600 ) )
     end
 
     def redis

--- a/lib/wilbertils/version.rb
+++ b/lib/wilbertils/version.rb
@@ -1,3 +1,3 @@
 module Wilbertils
-  VERSION = "1.13.0"
+  VERSION = "1.13.1"
 end


### PR DESCRIPTION
Some carriers don't have an expires_in value stored in Redis, so they use the default of 3600 seconds.