### PR TITLE
JWT token expiry support

### DIFF
--- a/lib/wilbertils/version.rb
+++ b/lib/wilbertils/version.rb
@@ -1,3 +1,3 @@
 module Wilbertils
-  VERSION = "1.13.1"
+  VERSION = "1.13.2"
 end


### PR DESCRIPTION
NZ Couriers send an expires in time outside the token but it's the time within the token that we need to be refreshing based on.