### PR TITLE
update holiday gem

### DIFF
--- a/spec/wilbertils/message_receiver_new_spec.rb
+++ b/spec/wilbertils/message_receiver_new_spec.rb
@@ -32,7 +32,7 @@ describe Wilbertils::MessageReceiverNew do
 
   end
 
-  subject { Wilbertils::MessageReceiverNew.new('queue_name', message_processor, message_translator, config, logger, TestShutdown.new(1)) }
+  subject { Wilbertils::MessageReceiverNew.new('queue_name', message_processor, message_translator, config, logger, 120, TestShutdown.new(1)) }
 
   before do
     expect(Wilbertils::SQS).to receive(:client).and_return(sqs_client)
@@ -67,7 +67,7 @@ describe Wilbertils::MessageReceiverNew do
     describe 'when a message without an id is encountered' do
       let(:message) { double('message', :message_id => '', :receipt_handle => 'xyz') }
       it 'logs an error but not raise an exception' do
-        expect(logger).to receive(:error).with /empty id/
+        expect(logger).to receive(:info).with /empty id/
         expect(message_translator).to_not receive(:new) # execution should short-circuit
         expect(sqs_client).to receive(:delete_message).with(queue_url: 'queue_name', receipt_handle: 'xyz')
         expect{ subject.poll }.to_not raise_error
@@ -77,7 +77,7 @@ describe Wilbertils::MessageReceiverNew do
     describe 'when a message without a nil id is encountered' do
       let(:message) { double('message', :message_id => nil, :receipt_handle => 'xyz') } # not sure this can actually happen
       it 'logs an error but not raise an exception' do
-        expect(logger).to receive(:error).with /nil id/
+        expect(logger).to receive(:info).with /nil id/
         expect(message_translator).to_not receive(:new) # execution should short-circuit
         expect(sqs_client).to receive(:delete_message).with(queue_url: 'queue_name', receipt_handle: 'xyz')
         expect{ subject.poll }.to_not raise_error
@@ -87,7 +87,7 @@ describe Wilbertils::MessageReceiverNew do
     describe 'when a message with an empty body is encountered' do
       let(:message) { double('message', :message_id => '123', :body => '', :receipt_handle => 'xyz') }
       it 'logs an error but not raise an exception' do
-        expect(logger).to receive(:error).with /empty body/
+        expect(logger).to receive(:info).with /empty body/
         expect(message_translator).to_not receive(:new) # execution should short-circuit
         expect(sqs_client).to receive(:delete_message).with(queue_url: 'queue_name', receipt_handle: 'xyz')
         expect{ subject.poll }.to_not raise_error
@@ -97,7 +97,7 @@ describe Wilbertils::MessageReceiverNew do
     describe 'when a message with a nil body is encountered' do
       let(:message) { double('message', :message_id => '123', :body => nil, :receipt_handle => 'xyz') } # not sure this can actually happen
       it 'logs an error but not raise an exception' do
-        expect(logger).to receive(:error).with /nil body/
+        expect(logger).to receive(:info).with /nil body/
         expect(message_translator).to_not receive(:new) # execution should short-circuit
         expect(sqs_client).to receive(:delete_message).with(queue_url: 'queue_name', receipt_handle: 'xyz')
         expect{ subject.poll }.to_not raise_error
@@ -109,7 +109,7 @@ describe Wilbertils::MessageReceiverNew do
         allow(message_processor).to receive(:execute).and_raise()
       end
 
-      subject { Wilbertils::MessageReceiverNew.new('queue_name', message_processor, message_translator, config, logger, TestShutdown.new(2) ) }
+      subject { Wilbertils::MessageReceiverNew.new('queue_name', message_processor, message_translator, config, logger, 120, TestShutdown.new(2) ) }
 
       it 'continues to poll' do
         expect(message_processor).to receive(:new).twice()

--- a/wilbertils.gemspec
+++ b/wilbertils.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'sucker_punch', '1.0.2'
   spec.add_runtime_dependency 'activesupport'
   spec.add_runtime_dependency 'redis-queue', '0.1.0'
-  spec.add_runtime_dependency 'holidays', '>= 8.6.0'
+  spec.add_runtime_dependency 'holidays', '~> 8.8.0'
   spec.add_runtime_dependency 'countries', '>= 5.2.0'
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated a runtime dependency requirement to a newer compatible version (from `>= 8.6.0` to `~> 8.8.0`).
  * Helps keep the project aligned with supported library releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->