### PR TITLE
update aws sdk gems

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ Or install it yourself as:
 
     $ gem install wilbertils
 
+## Live Local Wilbertils Updates in Docker
+Builds will pickup the current dev wilbertils with the COPY command, no changes required.
+Run docker commands with local wilbertils rather than the gem add `--env DEVELOPMENT=true` to commands (bundling local updates to wilbertils versions for example):
+`docker compose run --env DEVELOPMENT=true wilberforce bundle lock --conservative --update aws-sdk`
+
 ## Usage
 
 TODO: Write usage instructions here

--- a/lib/wilbertils.rb
+++ b/lib/wilbertils.rb
@@ -1,3 +1,6 @@
+require "aws-sdk-s3"
+require "aws-sdk-sqs"
+require "aws-sdk-ses"
 require "wilbertils/version"
 require "wilbertils/search/locality_search"
 require "wilbertils/toggle"

--- a/lib/wilbertils/file_archiver.rb
+++ b/lib/wilbertils/file_archiver.rb
@@ -1,18 +1,21 @@
 module Wilbertils
   class FileArchiver
-    
     class << self
-      def archive file:, upload_path:, bucket_name: 'mf-ftp-files'        
-        s3.bucket(bucket_name).object("#{ENV['ENVIRONMENT_NAME']}/#{upload_path}-#{Time.now.to_i}").upload_file(file)
+      def archive file:, upload_path:, bucket_name: 'mf-ftp-files'
+        object = s3.bucket(bucket_name).object("#{ENV['ENVIRONMENT_NAME']}/#{upload_path}-#{Time.now.to_i}")
+        transport_manager.upload_file(file, bucket: object.bucket_name, key: object.key)
         File.delete(file) unless ENV['ENVIRONMENT_NAME'].downcase == 'development'
       end
-      
+
       private
-      
+
       def s3
         @s3 ||= Aws::S3::Resource.new(region: ENV['AWS_REGION'])
       end
-      
+
+      def transport_manager
+        @tm ||= Aws::S3::TransferManager.new(client: s3.client)
+      end
     end
   end
 end

--- a/lib/wilbertils/version.rb
+++ b/lib/wilbertils/version.rb
@@ -1,3 +1,3 @@
 module Wilbertils
-  VERSION = "1.15.0"
+  VERSION = "1.16.0"
 end

--- a/wilbertils.gemspec
+++ b/wilbertils.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'newrelic_rpm', '~> 9.24'
   spec.add_runtime_dependency "statsd-ruby"
   spec.add_runtime_dependency "jwt", '2.5.0'
-  spec.add_runtime_dependency 'aws-sdk', '3.1.0'
+  spec.add_runtime_dependency 'aws-sdk', '3.3.0'
   spec.add_runtime_dependency 'airbrake', '13.0.5'
   spec.add_runtime_dependency 'sucker_punch', '1.0.2'
   spec.add_runtime_dependency 'activesupport'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a “Live Local Wilbertils Updates in Docker” section with guidance and an example for running Docker Compose using local development updates.

- **Bug Fixes**
  - Improved AWS availability by ensuring S3, SQS, and SES clients are loaded.
  - Updated S3 file uploading to use a managed transfer approach for uploads.
  - Updated the AWS SDK runtime dependency to 3.3.0.

- **Chores**
  - Bumped the Wilbertils version to 1.16.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->